### PR TITLE
Update `JWST()` function

### DIFF
--- a/xaosim/pupil.py
+++ b/xaosim/pupil.py
@@ -662,7 +662,7 @@ def JWST(sz, pscale=0.1, aperture="CLEARP"):
     # segmented aperture first
     # pop central segment!
     # ------------------------
-    scoords = hex_grid_coords(nr=3, radius=seg_rad, rot=0)
+    scoords = hex_grid_coords(nr=2, radius=seg_rad, rot=0)
     scoords = np.delete(scoords, scoords.shape[1]//2, axis=1)
     scoords = scoords.astype('int')
 

--- a/xaosim/pupil.py
+++ b/xaosim/pupil.py
@@ -626,7 +626,7 @@ def KBENCH(sz, pscale=100.0, noc=False, between_pix=False):
 
 
 # ==================================================================
-def JWST(sz, pscale=0.1, aperture="CLEARP"):
+def JWST(sz, pscale=0.0064486953125, aperture="CLEARP"):
     ''' ---------------------------------------------------------
     Returns a square (sz x sz) array filled with a representation
     of the JWST aperture.


### PR DESCRIPTION
Hi,

This updates the `JWST()` function to use 2 rings in the hexagonal grid (instead of 3), and the same default pscale as the one used for `JWST_NRM()`.

Here is a before/after with the right pixel scale

![image](https://user-images.githubusercontent.com/35547958/161315591-e59f74f7-0d57-4fa8-8ee4-0eb4c652789c.png)